### PR TITLE
 nwpu fix the problems in the referee(nwpu 修改了referee中存在的问题)

### DIFF
--- a/Referee/Referee.cpp
+++ b/Referee/Referee.cpp
@@ -2140,9 +2140,12 @@ int Team::Judge_FREE_BALL(Environment *pEnv)
 						{
 							if (Judge_Collision(statespace.home[i], statespace.home[robot]))
 							{
-								statespace.gameState = PM_FreeBall_LeftBot;
+								//There are more than one blue robot on the side.
+								//So gameState should be PM_FreeBall_RightBot
+								//And return 4
+								statespace.gameState = PM_FreeBall_RightBot;
 								Foul_pushball += 1;
-								return 2;
+								return 4;
 							}
 						}
 					}
@@ -2299,7 +2302,8 @@ int Team::Judge_FREE_BALL(Environment *pEnv)
 
 			for (int i = 0; i < 5; i++)
 			{
-				if (pEnv->opponent[i].pos.y > pEnv->currentBall.pos.y && pEnv->opponent[i].pos.x <= 8 && pEnv->opponent[i].pos.y <= 70)
+				//According to the previous "if" the pEnv->opponent[i].pos.x should be >=212
+				if (pEnv->opponent[i].pos.y > pEnv->currentBall.pos.y && pEnv->opponent[i].pos.x >= 212 && pEnv->opponent[i].pos.y <= 70)
 				{
 					if (getLength(pEnv->opponent[i].pos, pEnv->currentBall.pos) < 6.69)
 					{
@@ -2552,14 +2556,15 @@ int Team::Judge_FREE_BALL(Environment *pEnv)
 		{
 			for (int i = 0; i < 5; i++)
 			{
-				if (pEnv->home[i].pos.y > pEnv->currentBall.pos.y && pEnv->home[i].pos.x >= 212 && pEnv->home[i].pos.y <= 110)
+				//According to the previous "if" pEnv->home[i].pos.y should >=110
+				if (pEnv->home[i].pos.y > pEnv->currentBall.pos.y && pEnv->home[i].pos.x >= 212 && pEnv->home[i].pos.y >= 110)
 				{
 					if (getLength(pEnv->home[i].pos, pEnv->currentBall.pos) < 6.69)
 					{
 						tuiqiu3 = true;
 					}
 				}
-				if (pEnv->home[i].pos.y < pEnv->currentBall.pos.y && pEnv->home[i].pos.x >= 212 && pEnv->home[i].pos.y <= 110)
+				if (pEnv->home[i].pos.y < pEnv->currentBall.pos.y && pEnv->home[i].pos.x >= 212 && pEnv->home[i].pos.y >= 110)
 				{
 					if (getLength(pEnv->home[i].pos, pEnv->currentBall.pos) < 6.69)
 					{


### PR DESCRIPTION
1.对于争球判断，当满足pEnv->currentBall.pos.y <= 8时并且duiwu==1（蓝方）时，判断蓝方边路双人推球，返回的gameState为2，按照规则，应该返回gameState为4；同时当duiwu==2时，在蓝方边路双人推球时返回的为gameState为4，这就会导致自动摆位裁判摆放球的坐标以及机器人摆位坐标错误的问题。


2.对于争球判断，当满足pEnv->currentBall.pos.x >= 212 && pEnv->currentBall.pos.y <= 70时并且duiwu==2（黄方时），在判断蓝方是否推球时，选择条件是pEnv->opponent[i].pos.x <= 8,这样将导致黄方无法正常判断蓝方是否推球。而当duiwu==1（蓝方时），可以正常判断蓝方推球。这样导致的错误是，蓝方一旦出现边路双人推球，黄方将无法判别，只要蓝方出现一次边路双人推球，蓝方的双人推球次数就会不断的累加。

3.对于争球判断，当满足pEnv->currentBall.pos.x >= 212 && pEnv->currentBall.pos.y >= 110时，并且duiwu==1（蓝方时），选择条件是pEnv->home[i].pos.y <= 110，这样将导致蓝方永远不会自己推球。而黄方则会判断赛场形势是争球，这就会导致自动摆位裁判摆放球的坐标以及机器人摆位坐标错误的问题。